### PR TITLE
added stateRootAvailable to origin sub-graph schema

### DIFF
--- a/graph/origin/schema.graphql
+++ b/graph/origin/schema.graphql
@@ -1,3 +1,13 @@
+type StateRootAvailable @entity {
+  id: ID!
+  _blockHeight: BigInt! # uint256
+  _stateRoot: Bytes! # bytes32
+  blockNumber: BigInt! # uint256
+  blockHash: Bytes! # bytes32
+  contractAddress: Bytes! # address
+  uts: BigInt! # uint256
+}
+
 type StakeRequested @entity {
   id: ID!
   amount: BigInt! # uint256

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openst/mosaic-chains",
-  "version": "0.1.0-alpha.3",
+  "version": "0.1.0-alpha.4",
   "description": "Mosaic chains is an executable to run and manage mosaic chains.",
   "bin": {
     "mosaic": "lib/src/bin/mosaic.js"


### PR DESCRIPTION
Were seeing below errors in facilitator and this PR is to fix it

`error: Observer error: GraphQL error: Type Subscription has no field stateRootAvailables {"service":"facilitator","timestamp":"2019-09-27T07:45:17.494Z"}`