### PR TITLE
Setting up co-anchor on aux chain creations and enabled mosaic verify

### DIFF
--- a/src/NewChain/AuxiliaryChainInteract.ts
+++ b/src/NewChain/AuxiliaryChainInteract.ts
@@ -294,16 +294,31 @@ export default class AuxiliaryChainInteract {
   }
 
   /**
-   * This method set anchor organization admin.
+   * This method set organization admin.
    * @param admin Admin address.
-   * @param anchorOrganization AnchorOrganization contract interact.
+   * @param organization Organization contract interact.
    */
-  public async setAnchorOrganizationAdmin(
+  public async setOrganizationAdmin(
     admin: string,
-    anchorOrganization: ContractInteract.Organization,
+    organization: ContractInteract.Organization,
   ) {
     return MosaicUtils.sendTransaction(
-      anchorOrganization.contract.methods.setAdmin(admin),
+      organization.contract.methods.setAdmin(admin),
+      this.txOptions,
+    );
+  }
+
+  /**
+   * This method set co-anchor address;
+   * @param auxiliaryAnchor Instance of anchor contract on auxiliary chain.
+   * @param coAnchorAddress CoAnchor address.
+   */
+  public async setCoanchorAddress(
+    auxiliaryAnchor: ContractInteract.Anchor,
+    coAnchorAddress: string,
+  ) {
+    return auxiliaryAnchor.setCoAnchorAddress(
+      coAnchorAddress,
       this.txOptions,
     );
   }
@@ -587,7 +602,7 @@ export default class AuxiliaryChainInteract {
    * Nonce is often added to enforce failure when deploying in wrong order or missing a contract.
    * @returns The transaction options to use for transactions to the auxiliary chain.
    */
-  public get txOptions(): Tx {
+  private get txOptions(): Tx {
     return {
       from: this.deployer,
       gasPrice: '0',

--- a/src/NewChain/AuxiliaryChainInteract.ts
+++ b/src/NewChain/AuxiliaryChainInteract.ts
@@ -313,7 +313,7 @@ export default class AuxiliaryChainInteract {
    * @param auxiliaryAnchor Instance of anchor contract on auxiliary chain.
    * @param coAnchorAddress CoAnchor address.
    */
-  public async setCoanchorAddress(
+  public async setCoAnchorAddress(
     auxiliaryAnchor: ContractInteract.Anchor,
     coAnchorAddress: string,
   ) {

--- a/src/NewChain/ChainVerifier.ts
+++ b/src/NewChain/ChainVerifier.ts
@@ -286,14 +286,13 @@ export default class ChainVerifier {
       this.contractAddresses.origin.anchorAddress,
     );
 
-    // fixme mosaic create currently doesnot set co-anchor https://github.com/mosaicdao/mosaic-chains/issues/91
-    // const coAnchor = await anchorInstance.methods.coAnchor().call();
-    // this.validateDeployedAddress(
-    //   this.originWeb3,
-    //   coAnchor,
-    //   this.contractAddresses.auxiliary.anchorAddress,
-    //   'OriginAnchor: Invalid coAnchor address!!!',
-    // );
+    const coAnchor = await anchorInstance.methods.coAnchor().call();
+    ChainVerifier.validateDeployedAddress(
+      this.originWeb3,
+      coAnchor,
+      this.contractAddresses.auxiliary.anchorAddress,
+      'OriginAnchor: Invalid coAnchor address!!!',
+    );
 
     const organization = await anchorInstance.methods.organization().call();
     ChainVerifier.validateDeployedAddress(
@@ -323,14 +322,13 @@ export default class ChainVerifier {
       this.contractAddresses.auxiliary.anchorAddress,
     );
 
-    // fixme mosaic create currently does not set co-anchor https://github.com/mosaicdao/mosaic-chains/issues/91
-    // const coAnchor = await anchorInstance.methods.coAnchor().call();
-    // this.validateDeployedAddress(
-    //   this.auxiliaryWeb3,
-    //   coAnchor,
-    //   this.contractAddresses.origin.anchorAddress,
-    //   'AuxiliaryAnchor: Invalid coAnchor address!!!',
-    // );
+    const coAnchor = await anchorInstance.methods.coAnchor().call();
+    ChainVerifier.validateDeployedAddress(
+      this.auxiliaryWeb3,
+      coAnchor,
+      this.contractAddresses.origin.anchorAddress,
+      'AuxiliaryAnchor: Invalid coAnchor address!!!',
+    );
 
     const organization = await anchorInstance.methods.organization().call();
     ChainVerifier.validateDeployedAddress(

--- a/src/NewChain/ChainVerifier.ts
+++ b/src/NewChain/ChainVerifier.ts
@@ -288,7 +288,7 @@ export default class ChainVerifier {
 
     const coAnchor = await anchorInstance.methods.coAnchor().call();
     ChainVerifier.validateDeployedAddress(
-      this.originWeb3,
+      this.auxiliaryWeb3,
       coAnchor,
       this.contractAddresses.auxiliary.anchorAddress,
       'OriginAnchor: Invalid coAnchor address!!!',
@@ -324,7 +324,7 @@ export default class ChainVerifier {
 
     const coAnchor = await anchorInstance.methods.coAnchor().call();
     ChainVerifier.validateDeployedAddress(
-      this.auxiliaryWeb3,
+      this.originWeb3,
       coAnchor,
       this.contractAddresses.origin.anchorAddress,
       'AuxiliaryAnchor: Invalid coAnchor address!!!',

--- a/src/NewChain/Initialization.ts
+++ b/src/NewChain/Initialization.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { Utils as MosaicUtils } from '@openst/mosaic.js';
+import { Utils as MosaicUtils, ContractInteract } from '@openst/mosaic.js';
 import * as ip from 'ip';
 
 import InitConfig from '../Config/InitConfig';
@@ -72,6 +72,7 @@ export default class Initialization {
       originChainInteract,
       auxiliaryChainInteract,
       hashLockSecret,
+      initConfig,
     );
 
     await Initialization.resetOrganizationAdmins(
@@ -113,6 +114,7 @@ export default class Initialization {
     originChainInteract: OriginChainInteract,
     auxiliaryChainInteract: AuxiliaryChainInteract,
     hashLockSecret: string,
+    initConfig: InitConfig,
   ): Promise<void> {
     Logger.info('Creating auxiliary chain');
     Initialization.initializeDataDir(auxiliaryNodeDescription.mosaicDir);
@@ -177,8 +179,8 @@ export default class Initialization {
 
     Logger.info('Deploying auxiliary contract.');
     const {
-      anchorOrganization,
-      anchor,
+      anchorOrganization: auxiliaryAnchorOrganization,
+      anchor: auxiliaryAnchor,
       coGatewayAndOstPrimeOrganization,
       ostPrime,
       ostCoGateway,
@@ -193,11 +195,26 @@ export default class Initialization {
       hashLockSecret,
       proofData,
     );
+
+    await Initialization.setCoAnchors(
+      auxiliaryAnchor,
+      originAnchor,
+      auxiliaryChainInteract,
+      originChainInteract,
+    );
+
+    await Initialization.setAnchorOrganizationAdmins(
+      auxiliaryChainInteract,
+      originChainInteract,
+      initConfig,
+      originAnchorOrganization,
+      auxiliaryAnchorOrganization,
+    );
     Logger.info('Auxiliary contract deployed');
     const auxiliaryContracts = auxiliaryChain.contractAddresses.auxiliary;
 
-    auxiliaryContracts.anchorOrganizationAddress = Utils.toChecksumAddress(anchorOrganization.address);
-    auxiliaryContracts.anchorAddress = Utils.toChecksumAddress(anchor.address);
+    auxiliaryContracts.anchorOrganizationAddress = Utils.toChecksumAddress(auxiliaryAnchorOrganization.address);
+    auxiliaryContracts.anchorAddress = Utils.toChecksumAddress(auxiliaryAnchor.address);
     auxiliaryContracts.ostCoGatewayOrganizationAddress = Utils.toChecksumAddress(coGatewayAndOstPrimeOrganization.address);
     auxiliaryContracts.ostPrimeAddress = Utils.toChecksumAddress(ostPrime.address);
     auxiliaryContracts.ostEIP20CogatewayAddress = Utils.toChecksumAddress(ostCoGateway.address);
@@ -223,6 +240,58 @@ export default class Initialization {
     Logger.info('Intial stake and mint is successful');
     mosaicConfig.writeToMosaicConfigDirectory();
     Logger.info('Mosaic config is created');
+  }
+
+  /**
+   * This methods set co-anchors.
+   * @param auxiliaryAnchor Auxiliary anchor contract instance.
+   * @param originAnchor Origin anchor contract instance.
+   * @param auxiliaryChainInteract Auxiliary chain contract interact.
+   * @param originChainInteract Origin chain contract interact.
+   */
+  private static async setCoAnchors(
+    auxiliaryAnchor: ContractInteract.Anchor,
+    originAnchor: ContractInteract.Anchor,
+    auxiliaryChainInteract: AuxiliaryChainInteract,
+    originChainInteract: OriginChainInteract,
+  ) {
+    Logger.info('Setting up auxiliary co-auxiliaryAnchor');
+    await auxiliaryAnchor.setCoAnchorAddress(
+      originAnchor.address,
+      auxiliaryChainInteract.txOptions,
+    );
+    Logger.info('Setting up origin co-auxiliaryAnchor');
+    await originAnchor.setCoAnchorAddress(
+      auxiliaryAnchor.address,
+      originChainInteract.txOptions,
+    );
+  }
+
+  /**
+   * This method sets anchor organization admins.
+   * @param auxiliaryChainInteract Interact of auxiliary chain contract.
+   * @param originChainInteract Interact of origin chain contract.
+   * @param initConfig InitConfig instance.
+   * @param originAnchorOrganization origin anchor organization instance.
+   * @param auxiliaryAnchorOrganization auxiliary anchor organization instance.
+   */
+  private static async setAnchorOrganizationAdmins(
+    auxiliaryChainInteract: AuxiliaryChainInteract,
+    originChainInteract: OriginChainInteract,
+    initConfig: InitConfig,
+    originAnchorOrganization: ContractInteract.Organization,
+    auxiliaryAnchorOrganization: ContractInteract.Organization,
+  ) {
+    Logger.info('Setting up origin anchor organization admin');
+    await originChainInteract.setAnchorOrganizationAdmin(
+      initConfig.originAnchorOrganizationAdmin,
+      originAnchorOrganization,
+    );
+    Logger.info('Setting up auxiliary anchor organization admin');
+    await auxiliaryChainInteract.setAnchorOrganizationAdmin(
+      initConfig.auxiliaryAnchorOrganizationAdmin,
+      auxiliaryAnchorOrganization,
+    );
   }
 
   /**

--- a/src/NewChain/Initialization.ts
+++ b/src/NewChain/Initialization.ts
@@ -256,14 +256,14 @@ export default class Initialization {
     originChainInteract: OriginChainInteract,
   ) {
     Logger.info('Setting up auxiliary co-auxiliaryAnchor');
-    await auxiliaryAnchor.setCoAnchorAddress(
+    await auxiliaryChainInteract.setCoanchorAddress(
+      auxiliaryAnchor,
       originAnchor.address,
-      auxiliaryChainInteract.txOptions,
     );
     Logger.info('Setting up origin co-auxiliaryAnchor');
-    await originAnchor.setCoAnchorAddress(
+    await originChainInteract.setCoanchorAddress(
+      originAnchor,
       auxiliaryAnchor.address,
-      originChainInteract.txOptions,
     );
   }
 
@@ -283,12 +283,12 @@ export default class Initialization {
     auxiliaryAnchorOrganization: ContractInteract.Organization,
   ) {
     Logger.info('Setting up origin anchor organization admin');
-    await originChainInteract.setAnchorOrganizationAdmin(
+    await originChainInteract.setOrganizationAdmin(
       initConfig.originAnchorOrganizationAdmin,
       originAnchorOrganization,
     );
     Logger.info('Setting up auxiliary anchor organization admin');
-    await auxiliaryChainInteract.setAnchorOrganizationAdmin(
+    await auxiliaryChainInteract.setOrganizationAdmin(
       initConfig.auxiliaryAnchorOrganizationAdmin,
       auxiliaryAnchorOrganization,
     );

--- a/src/NewChain/Initialization.ts
+++ b/src/NewChain/Initialization.ts
@@ -256,12 +256,12 @@ export default class Initialization {
     originChainInteract: OriginChainInteract,
   ) {
     Logger.info('Setting up auxiliary co-auxiliaryAnchor');
-    await auxiliaryChainInteract.setCoanchorAddress(
+    await auxiliaryChainInteract.setCoAnchorAddress(
       auxiliaryAnchor,
       originAnchor.address,
     );
     Logger.info('Setting up origin co-auxiliaryAnchor');
-    await originChainInteract.setCoanchorAddress(
+    await originChainInteract.setCoAnchorAddress(
       originAnchor,
       auxiliaryAnchor.address,
     );

--- a/src/NewChain/OriginChainInteract.ts
+++ b/src/NewChain/OriginChainInteract.ts
@@ -240,7 +240,7 @@ export default class OriginChainInteract {
    * @param originAnchor Instance of anchor contract on origin chain.
    * @param coAnchorAddress CoAnchor address.
    */
-  public async setCoanchorAddress(
+  public async setCoAnchorAddress(
     originAnchor: ContractInteract.Anchor,
     coAnchorAddress: string,
   ) {

--- a/src/NewChain/OriginChainInteract.ts
+++ b/src/NewChain/OriginChainInteract.ts
@@ -1,5 +1,6 @@
-import { ContractInteract, Contracts as MosaicContracts } from '@openst/mosaic.js';
+import { ContractInteract, Contracts as MosaicContracts, Utils as MosaicUtils } from '@openst/mosaic.js';
 import Contract from 'web3/eth/contract';
+import { Tx } from 'web3/eth/types';
 import InitConfig from '../Config/InitConfig';
 import Logger from '../Logger';
 import Contracts from './Contracts';
@@ -209,6 +210,29 @@ export default class OriginChainInteract {
     merklePatriciaProof: ContractInteract.MerklePatriciaProof;
   }> {
     return Contracts.deployGatewayLibraries(web3, { from: deployer });
+  }
+
+
+  /**
+   * Returns Origin TX Options.
+   */
+  public get txOptions(): Tx {
+    return this.initConfig.originTxOptions;
+  }
+
+  /**
+   * This method set anchor organization admin.
+   * @param admin Admin address.
+   * @param anchorOrganization AnchorOrganization contract interact.
+   */
+  public async setAnchorOrganizationAdmin(
+    admin: string,
+    anchorOrganization: ContractInteract.Organization,
+  ) {
+    return MosaicUtils.sendTransaction(
+      anchorOrganization.contract.methods.setAdmin(admin),
+      this.txOptions,
+    );
   }
 
   /**

--- a/src/NewChain/OriginChainInteract.ts
+++ b/src/NewChain/OriginChainInteract.ts
@@ -216,21 +216,36 @@ export default class OriginChainInteract {
   /**
    * Returns Origin TX Options.
    */
-  public get txOptions(): Tx {
+  private get txOptions(): Tx {
     return this.initConfig.originTxOptions;
   }
 
   /**
-   * This method set anchor organization admin.
+   * This method set organization admin.
    * @param admin Admin address.
-   * @param anchorOrganization AnchorOrganization contract interact.
+   * @param organization Organization contract interact.
    */
-  public async setAnchorOrganizationAdmin(
+  public async setOrganizationAdmin(
     admin: string,
-    anchorOrganization: ContractInteract.Organization,
+    organization: ContractInteract.Organization,
   ) {
     return MosaicUtils.sendTransaction(
-      anchorOrganization.contract.methods.setAdmin(admin),
+      organization.contract.methods.setAdmin(admin),
+      this.txOptions,
+    );
+  }
+
+  /**
+   * This method set co-anchor address;
+   * @param originAnchor Instance of anchor contract on origin chain.
+   * @param coAnchorAddress CoAnchor address.
+   */
+  public async setCoanchorAddress(
+    originAnchor: ContractInteract.Anchor,
+    coAnchorAddress: string,
+  ) {
+    return originAnchor.setCoAnchorAddress(
+      coAnchorAddress,
       this.txOptions,
     );
   }

--- a/tests/NewChain/AuxiliaryChainInteract/SetCoanchorAddress.ts
+++ b/tests/NewChain/AuxiliaryChainInteract/SetCoanchorAddress.ts
@@ -1,0 +1,58 @@
+import 'mocha';
+import * as sinon from 'sinon';
+import { ContractInteract } from '@openst/mosaic.js';
+import InitConfig from '../../../src/Config/InitConfig';
+import AuxiliaryChainInteract
+  from '../../../src/NewChain/AuxiliaryChainInteract';
+import SpyAssert from '../../test_utils/SpyAssert';
+import NodeDescription from '../../../src/Node/NodeDescription';
+
+describe('AuxiliaryChainInteract.setCoanchorAddress()', () => {
+  let mockInitConfig;
+  const auxiliaryChainId = '123';
+  let auxiliaryChainInteract: AuxiliaryChainInteract;
+  let anchor;
+  let setCoAnchorSpy;
+  const fakeReceipt = 'TXReceipt';
+  const auxiliaryTxOptions = {
+    // Deployer address is not defined aux chain interact it's created on chain setup.
+    from: undefined,
+    gasPrice: '0',
+    gas: '10000000',
+  };
+  const coAnchorAddress = '0x000000000000000000000000000000000000002';
+
+  beforeEach(() => {
+    mockInitConfig = sinon.createStubInstance(InitConfig);
+
+    auxiliaryChainInteract = new AuxiliaryChainInteract(
+      mockInitConfig,
+      auxiliaryChainId,
+      'originChain',
+      new NodeDescription(auxiliaryChainId),
+    );
+
+    anchor = sinon.createStubInstance(ContractInteract.Anchor);
+    setCoAnchorSpy = sinon.replace(
+      anchor,
+      'setCoAnchorAddress',
+      sinon.fake.resolves(fakeReceipt),
+    );
+  });
+
+  it('should set co-anchor address', async () => {
+    await auxiliaryChainInteract.setCoanchorAddress(
+      anchor,
+      coAnchorAddress,
+    );
+
+    SpyAssert.assert(
+      setCoAnchorSpy,
+      1,
+      [[
+        coAnchorAddress,
+        auxiliaryTxOptions,
+      ]],
+    );
+  });
+});

--- a/tests/NewChain/AuxiliaryChainInteract/SetCoanchorAddress.ts
+++ b/tests/NewChain/AuxiliaryChainInteract/SetCoanchorAddress.ts
@@ -7,7 +7,7 @@ import AuxiliaryChainInteract
 import SpyAssert from '../../test_utils/SpyAssert';
 import NodeDescription from '../../../src/Node/NodeDescription';
 
-describe('AuxiliaryChainInteract.setCoanchorAddress()', () => {
+describe('AuxiliaryChainInteract.setCoAnchorAddress()', () => {
   let mockInitConfig;
   const auxiliaryChainId = '123';
   let auxiliaryChainInteract: AuxiliaryChainInteract;
@@ -41,7 +41,7 @@ describe('AuxiliaryChainInteract.setCoanchorAddress()', () => {
   });
 
   it('should set co-anchor address', async () => {
-    await auxiliaryChainInteract.setCoanchorAddress(
+    await auxiliaryChainInteract.setCoAnchorAddress(
       anchor,
       coAnchorAddress,
     );

--- a/tests/NewChain/OriginChainInteract/SetCoanchorAddress.ts
+++ b/tests/NewChain/OriginChainInteract/SetCoanchorAddress.ts
@@ -5,7 +5,7 @@ import InitConfig from '../../../src/Config/InitConfig';
 import OriginChainInteract from '../../../src/NewChain/OriginChainInteract';
 import SpyAssert from '../../test_utils/SpyAssert';
 
-describe('OriginChainInteract.setCoanchorAddress()', () => {
+describe('OriginChainInteract.setCoAnchorAddress()', () => {
   let mockInitConfig;
   let web3;
   const auxiliaryChainId = '123';
@@ -40,7 +40,7 @@ describe('OriginChainInteract.setCoanchorAddress()', () => {
   });
 
   it('should set co-anchor address', async () => {
-    await originChainInteract.setCoanchorAddress(
+    await originChainInteract.setCoAnchorAddress(
       anchor,
       coAnchorAddress,
     );

--- a/tests/NewChain/OriginChainInteract/SetCoanchorAddress.ts
+++ b/tests/NewChain/OriginChainInteract/SetCoanchorAddress.ts
@@ -1,0 +1,57 @@
+import 'mocha';
+import * as sinon from 'sinon';
+import { ContractInteract } from '@openst/mosaic.js';
+import InitConfig from '../../../src/Config/InitConfig';
+import OriginChainInteract from '../../../src/NewChain/OriginChainInteract';
+import SpyAssert from '../../test_utils/SpyAssert';
+
+describe('OriginChainInteract.setCoanchorAddress()', () => {
+  let mockInitConfig;
+  let web3;
+  const auxiliaryChainId = '123';
+  let originChainInteract: OriginChainInteract;
+  let anchor;
+  let setCoAnchorSpy;
+  const fakeReceipt = 'TXReceipt';
+  const originTxOptions = {
+    from: '0x000000000000000000000000000000000000001',
+  };
+  const coAnchorAddress = '0x000000000000000000000000000000000000002';
+
+  beforeEach(() => {
+    mockInitConfig = sinon.createStubInstance(InitConfig);
+
+    mockInitConfig.originTxOptions = originTxOptions;
+
+    web3 = sinon.fake();
+
+    originChainInteract = new OriginChainInteract(
+      mockInitConfig,
+      web3,
+      auxiliaryChainId,
+    );
+
+    anchor = sinon.createStubInstance(ContractInteract.Anchor);
+    setCoAnchorSpy = sinon.replace(
+      anchor,
+      'setCoAnchorAddress',
+      sinon.fake.resolves(fakeReceipt),
+    );
+  });
+
+  it('should set co-anchor address', async () => {
+    await originChainInteract.setCoanchorAddress(
+      anchor,
+      coAnchorAddress,
+    );
+
+    SpyAssert.assert(
+      setCoAnchorSpy,
+      1,
+      [[
+        coAnchorAddress,
+        originTxOptions,
+      ]],
+    );
+  });
+});


### PR DESCRIPTION
fixes #91 
This PR fixes bug in mosaic chain creations and set co-anchor after anchors are deployed. 