### PR TITLE
Print endpoints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4680,6 +4680,11 @@
         "object-visit": "^1.0.0"
       }
     },
+    "markdown-table": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-1.1.3.tgz",
+      "integrity": "sha512-1RUZVgQlpJSPWYbFSpmudq5nHY1doEIv89gBtF0s4gW1GF2XorxcA/70M5vq7rLv0a6mhOUccRsqkwhwLCIQ2Q=="
+    },
     "md5.js": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "fs-extra": "7.0.1",
     "ip": "1.1.5",
     "jsonschema": "1.2.4",
+    "markdown-table": "1.1.3",
     "mustache": "3.0.1",
     "rlp": "2.2.3",
     "ts-node": "8.0.3",

--- a/src/Graph/Graph.ts
+++ b/src/Graph/Graph.ts
@@ -1,9 +1,9 @@
 import * as path from 'path';
-import * as ip from 'ip';
 import Logger from '../Logger';
 import Shell from '../Shell';
 import GraphDescription from './GraphDescription';
 import Directory from '../Directory';
+import Utils from '../Utils';
 
 const waitPort = require('wait-port');
 
@@ -118,7 +118,7 @@ export default class Graph {
       `MOSAIC_GRAPH_POSTGRES_PORT=${this.postgresPort}`,
       `MOSAIC_GRAPH_DATA_FOLDER=${this.getMosaicGraphDataFolder()}`,
       `MOSAIC_ETHEREUM_RPC_PORT=${this.ethereumRpcPort}`,
-      `MOSAIC_GRAPH_NODE_HOST=${ip.address()}`,
+      `MOSAIC_GRAPH_NODE_HOST=${Utils.ipAddress}`,
       'docker-compose',
       `-f ${path.join(Directory.getProjectGraphDir(), 'docker-compose.yml')}`,
       '-p', this.containerName,

--- a/src/Graph/Graph.ts
+++ b/src/Graph/Graph.ts
@@ -118,7 +118,7 @@ export default class Graph {
       `MOSAIC_GRAPH_POSTGRES_PORT=${this.postgresPort}`,
       `MOSAIC_GRAPH_DATA_FOLDER=${this.getMosaicGraphDataFolder()}`,
       `MOSAIC_ETHEREUM_RPC_PORT=${this.ethereumRpcPort}`,
-      `MOSAIC_GRAPH_NODE_HOST=${Utils.ipAddress}`,
+      `MOSAIC_GRAPH_NODE_HOST=${Utils.ipAddress()}`,
       'docker-compose',
       `-f ${path.join(Directory.getProjectGraphDir(), 'docker-compose.yml')}`,
       '-p', this.containerName,

--- a/src/NewChain/Initialization.ts
+++ b/src/NewChain/Initialization.ts
@@ -373,6 +373,6 @@ export default class Initialization {
    * @param port Port of boot node.
    */
   private static getBootNode(auxiliaryChainInteract: AuxiliaryChainInteract, port: number) {
-    return `enode://${auxiliaryChainInteract.getBootNode()}@${Utils.ipAddress}:${port}`;
+    return `enode://${auxiliaryChainInteract.getBootNode()}@${Utils.ipAddress()}:${port}`;
   }
 }

--- a/src/NewChain/Initialization.ts
+++ b/src/NewChain/Initialization.ts
@@ -1,8 +1,8 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { Utils as MosaicUtils, ContractInteract } from '@openst/mosaic.js';
-import * as ip from 'ip';
 
+import Utils from '../Utils';
 import InitConfig from '../Config/InitConfig';
 import MosaicConfig, { AuxiliaryChain } from '../Config/MosaicConfig';
 import PublishMosaicConfig from '../Config/PublishMosaicConfig';
@@ -13,7 +13,6 @@ import Logger from '../Logger';
 import Proof from './Proof';
 import Directory from '../Directory';
 import Integer from '../Integer';
-import Utils from '../Utils';
 
 import Web3 = require('web3');
 
@@ -374,6 +373,6 @@ export default class Initialization {
    * @param port Port of boot node.
    */
   private static getBootNode(auxiliaryChainInteract: AuxiliaryChainInteract, port: number) {
-    return `enode://${auxiliaryChainInteract.getBootNode()}@${ip.address()}:${port}`;
+    return `enode://${auxiliaryChainInteract.getBootNode()}@${Utils.ipAddress}:${port}`;
   }
 }

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1,4 +1,5 @@
 import Web3 = require('web3');
+import * as ip from 'ip';
 
 /**
  * It contains utility methods.
@@ -12,5 +13,13 @@ export default class Utils {
    */
   public static toChecksumAddress(address: string): string {
     return Web3.utils.toChecksumAddress(address);
+  }
+
+  /**
+   * It return ip address of the system.
+   * @returns  Ip address.
+   */
+  public static get ipAddress(): string {
+    return ip.address();
   }
 }

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -19,7 +19,7 @@ export default class Utils {
    * It return ip address of the system.
    * @returns  Ip address.
    */
-  public static get ipAddress(): string {
+  public static ipAddress(): string {
     return ip.address();
   }
 }

--- a/src/bin/mosaic-start.ts
+++ b/src/bin/mosaic-start.ts
@@ -12,7 +12,7 @@ import DevChainOptions from './DevChainOptions';
 import Logger from '../Logger';
 import { default as ChainInfo, GETH_CLIENT, PARITY_CLIENT } from '../Node/ChainInfo';
 import Validator from './Validator';
-
+import * as markdownTable from 'markdown-table';
 let mosaic = commander
   .arguments('<chain>');
 
@@ -119,9 +119,9 @@ mosaic
       };
       const node: Node = NodeFactory.create(nodeDescription);
       node.start();
-
+      let graphDescription: GraphDescription;
       if (!optionInput.withoutGraphNode) {
-        const graphDescription: GraphDescription = GraphOptions.parseOptions(
+        graphDescription = GraphOptions.parseOptions(
           optionInput,
           chainInput,
         );
@@ -132,6 +132,16 @@ mosaic
 
         await (new Graph(graphDescription).start());
       }
+      // printing of endpoints on console.
+      const endPointsTable = markdownTable([
+        ["","rpc port", "ws port"],
+        [chain, rpcPort, websocketPort],
+        ["Graph node", graphDescription.rpcPort, graphDescription.websocketPort],
+      ],{
+        align: ['c'],
+        },
+      );
+      Logger.info(`\n below is the list of endpoints : \n${endPointsTable}\n\n`);
     } catch (e) {
       Logger.error(`Error starting node: ${e} `);
     }

--- a/src/bin/mosaic-start.ts
+++ b/src/bin/mosaic-start.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import * as commander from 'commander';
+import * as markdownTable from 'markdown-table';
 import NodeFactory from '../Node/NodeFactory';
 import Node from '../Node/Node';
 import NodeOptions from './NodeOptions';
@@ -12,7 +13,7 @@ import DevChainOptions from './DevChainOptions';
 import Logger from '../Logger';
 import { default as ChainInfo, GETH_CLIENT, PARITY_CLIENT } from '../Node/ChainInfo';
 import Validator from './Validator';
-import * as markdownTable from 'markdown-table';
+
 let mosaic = commander
   .arguments('<chain>');
 
@@ -134,13 +135,12 @@ mosaic
       }
       // printing of endpoints on console.
       const endPointsTable = markdownTable([
-        ["","rpc port", "ws port"],
+        ['', 'rpc port', 'ws port'],
         [chain, rpcPort, websocketPort],
-        ["Graph node", graphDescription.rpcPort, graphDescription.websocketPort],
-      ],{
-        align: ['c'],
-        },
-      );
+        ['Graph node', graphDescription.rpcPort, graphDescription.websocketPort],
+      ], {
+        align: ['c', 'c', 'c'],
+      });
       Logger.info(`\n below is the list of endpoints : \n${endPointsTable}\n\n`);
     } catch (e) {
       Logger.error(`Error starting node: ${e} `);

--- a/src/bin/mosaic-start.ts
+++ b/src/bin/mosaic-start.ts
@@ -136,7 +136,7 @@ mosaic
         await (new Graph(graphDescription).start());
       }
 
-      const ipAddress = Utils.ipAddress;
+      const ipAddress = Utils.ipAddress();
       // printing of endpoints on console.
       const chainEndPoints = markdownTable([
         ['', 'url'],
@@ -146,6 +146,7 @@ mosaic
         align: ['c', 'c'],
       });
 
+      Logger.info(`\n below is the list of endpoints for ${chain} chain : \n${chainEndPoints}\n\n`);
       if (isGraphServices) {
         const graphNodeEndPoints = markdownTable([
           ['', 'url'],
@@ -169,8 +170,6 @@ mosaic
         ], {
           align: ['c', 'c'],
         });
-
-        Logger.info(`\n below is the list of endpoints for ${chain} chain : \n${chainEndPoints}\n\n`);
         Logger.info(`\n\n below is the list of endpoints for graph node : \n${graphNodeEndPoints}\n\n`);
         Logger.info(`\n\n below is the list of endpoints for postgres db : \n${postGresEndPoints}\n\n`);
         Logger.info(`\n\n below is the list of endpoints for ipfs : \n${ipfsEndPoints}\n\n`);


### PR DESCRIPTION
PR contains changes to print geth and graph endpoints on console in **mosais-start**.
It uses **markdown-table** npm package to format the output.
fixes #194 