### PR TITLE
Upgrade 1405 to run on Istanbul EVM

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,20 @@ Please use one of below combinations:
 The chain id of future auxiliary chains running against Ethereum mainnet will increase by one number each.
 The chain id of future auxiliary chains running against Ethereum testnet will decrease by one number each.
 
+### Upgrading 1405 to Istanbul
+
+Istanbul EVM would be applied to 1405 at a block height of 3621496 which is likely to be mined around December, 4, 2019, 1 PM Berlin Time (GMT+1))
+
+#### If you were already running a node follow the below steps to upgrade
+
+```bash
+# stop chain.
+./mosaic stop 1405
+
+# for once start chain with `forceInit` flag (this would do a geth init using updated genesis file on the existing data dir).   
+./mosaic start 1405 --origin goerli --forceInit
+```
+
 ## Dev chains
 For development, you can use the dev chains. These chains have the initial chain setup contracts deployed. 
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,13 @@ Istanbul EVM would be applied to 1405 at a block height of 3621496 which is like
 ./mosaic start 1405 --origin goerli --forceInit
 ```
 
+#### Else 
+
+```bash
+# start chain command would take care of it.
+./mosaic start 1405 --origin goerli 
+```
+
 ## Dev chains
 For development, you can use the dev chains. These chains have the initial chain setup contracts deployed. 
 

--- a/chains/goerli/1405/genesis.json
+++ b/chains/goerli/1405/genesis.json
@@ -7,6 +7,9 @@
     "eip155Block": 0,
     "eip158Block": 0,
     "byzantiumBlock": 0,
+    "constantinopleBlock": 3621494,
+    "petersburgBlock": 3621495,
+    "istanbulBlock": 3621496,
     "clique": {
       "period": 3,
       "epoch": 30000

--- a/src/Node/GethNode.ts
+++ b/src/Node/GethNode.ts
@@ -142,13 +142,9 @@ export default class GethNode extends Node {
    * It initializes the geth directory from genesis file if not already done.
    */
   private initializeGethDirectory(): void {
-    if (!this.isGethAlreadyInitiliazed()) {
-      const { gethInitArgs } = this;
-      this.logInfo('initializing geth directory');
-      Shell.executeDockerCommand(gethInitArgs);
-    } else {
-      this.logInfo('skipping directory initialization as it is already done');
-    }
+    const { gethInitArgs } = this;
+    this.logInfo('initializing geth directory');
+    Shell.executeDockerCommand(gethInitArgs);
   }
 
   /**

--- a/src/Node/GethNode.ts
+++ b/src/Node/GethNode.ts
@@ -20,13 +20,13 @@ export default class GethNode extends Node {
   public clefSigner?: string;
 
   /** if set, code will perform geth init before starting node. Defaults to false. */
-  public forceGethInit?: boolean;
+  public forceInit?: boolean;
 
   public constructor(nodeDescription: NodeDescription) {
     super(nodeDescription);
     this.bootNodesFile = nodeDescription.bootNodesFile;
     this.clefSigner = nodeDescription.clefSigner;
-    this.forceGethInit = nodeDescription.forceGethInit;
+    this.forceInit = nodeDescription.forceInit;
   }
 
   /** A list of bootnodes that are passed to the geth container. */
@@ -145,7 +145,7 @@ export default class GethNode extends Node {
    * It initializes the geth directory from genesis file if not already done.
    */
   private initializeGethDirectory(): void {
-    if (this.forceGethInit || !this.isGethAlreadyInitiliazed()) {
+    if (this.forceInit || !this.isGethAlreadyInitiliazed()) {
       const { gethInitArgs } = this;
       this.logInfo('initializing geth directory');
       Shell.executeDockerCommand(gethInitArgs);

--- a/src/Node/GethNode.ts
+++ b/src/Node/GethNode.ts
@@ -19,11 +19,14 @@ export default class GethNode extends Node {
   /** RPC and IPC endpoint of clef */
   public clefSigner?: string;
 
+  /** if set, code will perform geth init before starting node. Defaults to false. */
+  public forceGethInit?: boolean;
 
   public constructor(nodeDescription: NodeDescription) {
     super(nodeDescription);
     this.bootNodesFile = nodeDescription.bootNodesFile;
     this.clefSigner = nodeDescription.clefSigner;
+    this.forceGethInit = nodeDescription.forceGethInit;
   }
 
   /** A list of bootnodes that are passed to the geth container. */
@@ -142,9 +145,13 @@ export default class GethNode extends Node {
    * It initializes the geth directory from genesis file if not already done.
    */
   private initializeGethDirectory(): void {
-    const { gethInitArgs } = this;
-    this.logInfo('initializing geth directory');
-    Shell.executeDockerCommand(gethInitArgs);
+    if (this.forceGethInit || !this.isGethAlreadyInitiliazed()) {
+      const { gethInitArgs } = this;
+      this.logInfo('initializing geth directory');
+      Shell.executeDockerCommand(gethInitArgs);
+    } else {
+      this.logInfo('skipping directory initialization as it is already done');
+    }
   }
 
   /**

--- a/src/Node/NodeDescription.ts
+++ b/src/Node/NodeDescription.ts
@@ -26,7 +26,7 @@ export default class NodeDescription {
 
   public clefSigner?: string;
 
-  public forceGethInit?: boolean;
+  public forceInit?: boolean;
 
   constructor(readonly chain: string) { }
 }

--- a/src/Node/NodeDescription.ts
+++ b/src/Node/NodeDescription.ts
@@ -26,5 +26,7 @@ export default class NodeDescription {
 
   public clefSigner?: string;
 
+  public forceGethInit?: boolean;
+
   constructor(readonly chain: string) { }
 }

--- a/src/bin/NodeOptions.ts
+++ b/src/bin/NodeOptions.ts
@@ -50,6 +50,9 @@ export default class NodeOptions {
   /** RPC and IPC endpoint of clef */
   public clefSigner?: string;
 
+  /** if set, code will perform geth init before starting node. Defaults to false. */
+  public forceGethInit?: boolean;
+
   /**
    * @param options The options from the command line.
    */
@@ -64,6 +67,7 @@ export default class NodeOptions {
     originChain: string;
     bootNodesFile: string;
     clefSigner: string;
+    forceGethInit: boolean;
   }) {
     Object.assign(this, options);
     this.bootNodesFile = options.bootNodesFile;
@@ -84,7 +88,8 @@ export default class NodeOptions {
       .option('-p,--port <port>', 'the port to use for forwarding from host to container', Integer.parseString)
       .option('-r,--rpc-port <port>', 'the RPC port to use for forwarding from host to container', Integer.parseString)
       .option('-w,--ws-port <port>', 'the WS port to use for forwarding from host to container', Integer.parseString)
-      .option('-k,--keep', 'if set, the container will not automatically be deleted when stopped');
+      .option('-k,--keep', 'if set, the container will not automatically be deleted when stopped')
+      .option('-f,--forceGethInit', 'if set, code will perform geth init before starting node');
     return command;
   }
 
@@ -107,6 +112,7 @@ export default class NodeOptions {
       originChain: options.origin || '',
       bootNodesFile: options.bootnodes,
       clefSigner: options.clefSigner,
+      forceGethInit: !!options.forceGethInit,
     });
 
     parsedOptions.mosaicDir = Directory.sanitize(parsedOptions.mosaicDir);

--- a/src/bin/NodeOptions.ts
+++ b/src/bin/NodeOptions.ts
@@ -51,7 +51,7 @@ export default class NodeOptions {
   public clefSigner?: string;
 
   /** if set, code will perform geth init before starting node. Defaults to false. */
-  public forceGethInit?: boolean;
+  public forceInit?: boolean;
 
   /**
    * @param options The options from the command line.
@@ -67,7 +67,7 @@ export default class NodeOptions {
     originChain: string;
     bootNodesFile: string;
     clefSigner: string;
-    forceGethInit: boolean;
+    forceInit: boolean;
   }) {
     Object.assign(this, options);
     this.bootNodesFile = options.bootNodesFile;
@@ -89,7 +89,7 @@ export default class NodeOptions {
       .option('-r,--rpc-port <port>', 'the RPC port to use for forwarding from host to container', Integer.parseString)
       .option('-w,--ws-port <port>', 'the WS port to use for forwarding from host to container', Integer.parseString)
       .option('-k,--keep', 'if set, the container will not automatically be deleted when stopped')
-      .option('-f,--forceGethInit', 'if set, code will perform geth init before starting node');
+      .option('-f,--forceInit', 'if set, code will perform geth init before starting node');
     return command;
   }
 
@@ -112,7 +112,7 @@ export default class NodeOptions {
       originChain: options.origin || '',
       bootNodesFile: options.bootnodes,
       clefSigner: options.clefSigner,
-      forceGethInit: !!options.forceGethInit,
+      forceInit: !!options.forceInit,
     });
 
     parsedOptions.mosaicDir = Directory.sanitize(parsedOptions.mosaicDir);

--- a/src/bin/NodeOptions.ts
+++ b/src/bin/NodeOptions.ts
@@ -89,7 +89,7 @@ export default class NodeOptions {
       .option('-r,--rpc-port <port>', 'the RPC port to use for forwarding from host to container', Integer.parseString)
       .option('-w,--ws-port <port>', 'the WS port to use for forwarding from host to container', Integer.parseString)
       .option('-k,--keep', 'if set, the container will not automatically be deleted when stopped')
-      .option('-f,--forceInit', 'if set, code will perform geth init before starting node');
+      .option('-f,--force-init', 'if set, code will perform geth init before starting node');
     return command;
   }
 

--- a/src/bin/mosaic-start.ts
+++ b/src/bin/mosaic-start.ts
@@ -49,7 +49,7 @@ function validateClientOption(chain, options) {
       Logger.error('Parity client is not supported for auxiliary-chains');
       return false;
     }
-    if (options.forceGethInit) {
+    if (options.forceInit) {
       Logger.error('geth init can not be performed for Parity client.');
       return false;
     }
@@ -103,7 +103,7 @@ mosaic
         originChain,
         bootNodesFile,
         clefSigner,
-        forceGethInit,
+        forceInit,
       } = NodeOptions.parseOptions(optionInput, chainInput);
 
       if (originChain && originChain.length > 0) {
@@ -134,7 +134,7 @@ mosaic
         client: optionInput.client,
         bootNodesFile,
         clefSigner,
-        forceGethInit,
+        forceInit,
       };
       const node: Node = NodeFactory.create(nodeDescription);
       node.start();

--- a/src/bin/mosaic-start.ts
+++ b/src/bin/mosaic-start.ts
@@ -49,6 +49,10 @@ function validateClientOption(chain, options) {
       Logger.error('Parity client is not supported for auxiliary-chains');
       return false;
     }
+    if (options.forceGethInit) {
+      Logger.error('geth init can not be performed for Parity client.');
+      return false;
+    }
     if (DevChainOptions.isDevChain(chain, options)) {
       Logger.error('Parity client is not supported for dev-chains');
       return false;
@@ -99,6 +103,7 @@ mosaic
         originChain,
         bootNodesFile,
         clefSigner,
+        forceGethInit,
       } = NodeOptions.parseOptions(optionInput, chainInput);
 
       if (originChain && originChain.length > 0) {
@@ -129,6 +134,7 @@ mosaic
         client: optionInput.client,
         bootNodesFile,
         clefSigner,
+        forceGethInit,
       };
       const node: Node = NodeFactory.create(nodeDescription);
       node.start();

--- a/src/bin/mosaic-start.ts
+++ b/src/bin/mosaic-start.ts
@@ -50,7 +50,7 @@ function validateClientOption(chain, options) {
       return false;
     }
     if (options.forceInit) {
-      Logger.error('geth init can not be performed for Parity client.');
+      Logger.error('Force init can not be performed for Parity client.');
       return false;
     }
     if (DevChainOptions.isDevChain(chain, options)) {


### PR DESCRIPTION
We used to initially check if data dir exists before calling `geth init`. now we accept an optional param in start command

`./mosaic start 1405 --origin goerli --forceGethInit`

Also not 100 % sure if should add migration instructions in Readme. If we feel so would add